### PR TITLE
Relax aeson and text deps to support versions 2.x

### DIFF
--- a/postgresql-ltree/postgresql-ltree.cabal
+++ b/postgresql-ltree/postgresql-ltree.cabal
@@ -30,10 +30,10 @@ library
   hs-source-dirs: src
   build-depends:
       base >=4.7 && <5
-    , aeson >=1.5.6.0 && <2
+    , aeson >=1.5.6.0 && <2.3
     , attoparsec >=0.13.2.5 && <1
     , containers >=0.6.5.1 && <1
-    , text >=1.2.4.1 && <2
+    , text >=1.2.4.1 && <2.1
     , uuid >=1.3.15 && <2
   default-language: Haskell2010
   ghc-options:

--- a/postgresql-simple-ltree/postgresql-simple-ltree.cabal
+++ b/postgresql-simple-ltree/postgresql-simple-ltree.cabal
@@ -31,10 +31,10 @@ library
       src
   build-depends:
       base >=4.7 && <5
-    , aeson >=1.5.6.0 && <2
+    , aeson >=1.5.6.0 && <2.3
     , postgresql-ltree >=0.0.0.0 && <1
     , postgresql-simple >=0.6.4 && <1
-    , text >=1.2.4.1 && <2
+    , text >=1.2.4.1 && <2.1
   default-language: Haskell2010
   ghc-options:
     -Wall -fwarn-tabs -Wincomplete-uni-patterns


### PR DESCRIPTION
Gets things building with LTS-21.1. The deps ranges should also be compatible with with the nightly LTS, which is `nightly-2023-07-05` at the time of this writing.